### PR TITLE
Add support for Valve Controller category "sfkzq" product "0axr5s0b"

### DIFF
--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -445,6 +445,14 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
             ),
         },
     ),
+    "sfkzq": TuyaBLECategoryInfo(
+        products={
+            "0axr5s0b":  # device product_id
+            TuyaBLEProductInfo(
+                name="Valve controller",
+            ),
+        },
+    ),
     "dd": TuyaBLECategoryInfo(
         products={
             **dict.fromkeys(

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -428,6 +428,23 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
             ],
         },
     ),
+    "sfkzq": TuyaBLECategoryNumberMapping(
+        products={
+            "0axr5s0b": [  # Valve Controller
+                TuyaBLENumberMapping(
+                    dp_id=11,
+                    description=NumberEntityDescription(
+                        key="countdown_duration",
+                        icon="mdi:timer",
+                        native_max_value=86400,
+                        native_min_value=1,
+                        native_unit_of_measurement=UnitOfTime.SECONDS,
+                        native_step=1,
+                    ),
+                ),
+            ],
+        },
+    ),
 }
 
 

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -204,6 +204,38 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
             ],
         },
     ),
+    "sfkzq": TuyaBLECategorySelectMapping(
+        products={
+            "0axr5s0b":  # Valve Controller
+            [
+                TuyaBLESelectMapping(
+                    dp_id=10,
+                    description=SelectEntityDescription(
+                        key="weather_delay",
+                        options=[
+                            "cancel",
+                            "24h",
+                            "48h",
+                            "72h",
+                        ],
+                        entity_category=EntityCategory.CONFIG,
+                    ),
+                ),
+                TuyaBLESelectMapping(
+                    dp_id=12,
+                    description=SelectEntityDescription(
+                        key="work_state",
+                        options=[
+                            "auto",
+                            "manual",
+                            "idle"
+                        ],
+                        entity_category=EntityCategory.CONFIG,
+                    ),
+                ),
+            ],
+        }
+    ),
 }
 
 

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -305,6 +305,23 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
             ],
         },
     ),
+    "sfkzq": TuyaBLECategorySensorMapping(
+        products={
+            "0axr5s0b": [  # Valve Controller
+                TuyaBLEBatteryMapping(dp_id=7),
+                TuyaBLESensorMapping(
+                    #dp_id=15,
+                    dp_id=11,
+                    description=SensorEntityDescription(
+                        key="time_left",
+                        device_class=SensorDeviceClass.DURATION,
+                        native_unit_of_measurement=UnitOfTime.SECONDS,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    ),
+                ),
+            ],
+        },
+    ),
 }
 
 

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -328,6 +328,19 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
             ],
         },
     ),
+    "sfkzq": TuyaBLECategorySwitchMapping(
+        products={
+            "0axr5s0b": [  # Valve Controller
+                TuyaBLESwitchMapping(
+                    dp_id=1,
+                    description=SwitchEntityDescription(
+                        key="water_valve",
+                        entity_registry_enabled_default=True,
+                    ),
+                ),
+            ],
+        },
+    ),
 }
 
 


### PR DESCRIPTION
Add support for Valve Controller category "sfkzq" product "0axr5s0b"

2024-03-20 14:11:25.471 DEBUG (MainThread) [custom_components.tuya_ble.cloud] Retrieved: uuid: xxxxxxxxxxxxxxxx, local_key: xxxxxxxxxxxxxxxx, device_id: xxxxxxxxxxxxxxxx, category: sfkzq, product_id: 0axr5s0b, device_name: Valve Controller, product_model: GN-220020, product_name: Valve Controllerfunctions: [{'code': 'switch', 'dp_id': 1, 'type': 'Boolean', 'values': '{}'}, {'code': 'weather_delay', 'dp_id': 10, 'type': 'Enum', 'values': '{"range":["cancel","24h","48h","72h"]}'}, {'code': 'countdown', 'dp_id': 11, 'type': 'Integer', 'values': '{"unit":"s","min":0,"max":86400,"scale":0,"step":1}'}]status_range: [{'code': 'switch', 'dp_id': 1, 'type': 'Boolean', 'values': '{}'}, {'code': 'battery_percentage', 'dp_id': 7, 'type': 'Integer', 'values': '{"unit":"%","min":0,"max":100,"scale":0,"step":1}'}, {'code': 'battery_state', 'dp_id': 8, 'type': 'Enum', 'values': '{"range":["low","middle","high"]}'}, {'code': 'use_time', 'dp_id': 9, 'type': 'Integer', 'values': '{"unit":"s","min":0,"max":2592000,"scale":0,"step":1}'}, {'code': 'weather_delay', 'dp_id': 10, 'type': 'Enum', 'values': '{"range":["cancel","24h","48h","72h"]}'}, {'code': 'countdown', 'dp_id': 11, 'type': 'Integer', 'values': '{"unit":"s","min":0,"max":86400,"scale":0,"step":1}'}, {'code': 'work_state', 'dp_id': 12, 'type': 'Enum', 'values': '{"range":["auto","manual","idle"]}'}, {'code': 'use_time_one', 'dp_id': 15, 'type': 'Integer', 'values': '{"unit":"s","min":0,"max":86400,"scale":0,"step":1}'}]