### PR TITLE
Do not set entity_id with a hardcoded sensor domain

### DIFF
--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -11,7 +11,6 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import (
     DeviceInfo,
     EntityDescription,
-    generate_entity_id,
 )
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import (
@@ -83,9 +82,6 @@ class TuyaBLEEntity(CoordinatorEntity):
         self._attr_has_entity_name = True
         self._attr_device_info = get_device_info(self._device)
         self._attr_unique_id = f"{self._device.device_id}-{description.key}"
-        self.entity_id = generate_entity_id(
-            "sensor.{}", self._attr_unique_id, hass=hass
-        )
 
     @property
     def available(self) -> bool:


### PR DESCRIPTION
## Problem

`TuyaBLEEntity.__init__` assigns `entity_id` with a hardcoded `sensor.` domain for **every** platform:

```python
self.entity_id = generate_entity_id("sensor.{}", self._attr_unique_id, hass=hass)
```

Since `TuyaBLEEntity` is the base class for all ten platforms, a lock, switch, light or climate entity ends up with a `sensor.*` entity_id. Home Assistant warns about this on every start and it becomes a hard error in 2027.5:

```
2026-08-10 10:08:53 WARNING (homeassistant.helpers.frame) [helpers/frame.py:305]
Detected that custom integration 'tuya_ble' sets an entity ID with wrong domain:
'sensor.bf3f24wti4usjfb1_lock'. Expected domain is 'lock'.
This will stop working in Home Assistant 2027.5.0, please report it to the author
of the 'tuya_ble' custom integration
```

On the reporting system the lock entity is present in the state machine but **not** in the entity registry, with state `unknown` and no `friendly_name`.

## Fix

Per the Home Assistant developer docs — [Entity IDs with mismatched domains are deprecated](https://developers.home-assistant.io/blog/2026/04/07/entity-id-mismatched-domain-deprecated/):

> Integrations that set `entity_id` directly on an entity will now be validated to ensure the domain portion matches the platform's domain.
>
> **In most cases, integrations should not set `entity_id` at all — Home Assistant will generate it automatically.**

So the assignment is removed rather than repaired. `_attr_has_entity_name = True` is already set two lines above and `_attr_translation_key` falls back to `description.key`, so Home Assistant has everything it needs to derive the entity_id from the platform domain plus the device and entity names.

`generate_entity_id` becomes unused and is dropped from the import.

## Impact

- Entities that are **in the entity registry** keep their current `entity_id` — the registry is the source of truth for those, so existing automations and dashboards referring to them keep working.
- Entities that never made it into the registry are a different case: on the reporting system the lock exists only in the state machine, as `sensor.<device_id>_lock` with state `unknown` and no name. There is no registry entry to preserve, so it will show up as a new `lock.*` entity and anything referring to the old id needs updating. I have not established why that entity is missing from the registry, so I would rather flag this than claim it is a no-op.
- Newly added devices get readable ids such as `lock.smart_lock_lock` instead of `sensor.<tuya_device_id>_lock`.
- `_attr_unique_id` is untouched, so registry identity does not change.

## Verification

- `python -m compileall custom_components/tuya_ble` passes.
- No other reference to `entity_id` or `generate_entity_id` remains in the integration.

Reported against `2026.05.14` on Home Assistant Core 2026.8 (HAOS, Python 3.14).

https://claude.ai/code/session_01BA8D88w54PfoqN6p5RRXGj
