### PR TITLE
Use UnitOfRatio.PARTS_PER_MILLION instead of deprecated constant

### DIFF
--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -13,8 +13,8 @@ from homeassistant.components.number import (
 from homeassistant.components.number.const import NumberDeviceClass, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    CONCENTRATION_PARTS_PER_MILLION,
     PERCENTAGE,
+    UnitOfRatio,
     UnitOfTemperature,
     UnitOfTime,
     UnitOfVolume,
@@ -239,7 +239,7 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
                         icon="mdi:molecule-co2",
                         native_max_value=5000,
                         native_min_value=400,
-                        native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+                        native_unit_of_measurement=UnitOfRatio.PARTS_PER_MILLION,
                         native_step=100,
                         entity_category=EntityCategory.CONFIG,
                     ),

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -14,9 +14,9 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    CONCENTRATION_PARTS_PER_MILLION,
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    UnitOfRatio,
     UnitOfTemperature,
     UnitOfTime,
     UnitOfVolume,
@@ -127,7 +127,7 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                     description=SensorEntityDescription(
                         key="carbon_dioxide",
                         device_class=SensorDeviceClass.CO2,
-                        native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+                        native_unit_of_measurement=UnitOfRatio.PARTS_PER_MILLION,
                         state_class=SensorStateClass.MEASUREMENT,
                     ),
                 ),

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
   "name": "Tuya BLE",
   "content_in_root": false,
-  "render_readme": true
+  "render_readme": true,
+  "homeassistant": "2026.7.0"
 }


### PR DESCRIPTION
## Problem

The integration uses `homeassistant.const.CONCENTRATION_PARTS_PER_MILLION`, which is deprecated. Home Assistant logs this twice on every start:

```
2026-08-10 10:08:49 WARNING (homeassistant.const) [helpers/deprecation.py:272]
The deprecated constant CONCENTRATION_PARTS_PER_MILLION was used from tuya_ble.
It will be removed in HA Core 2027.8. Use UnitOfRatio.PARTS_PER_MILLION instead,
please report it to the author of the 'tuya_ble' custom integration
```

Two usages: the CO2 sensor (`sensor.py`) and the CO2 alarm level number (`number.py`).

## Fix

```python
# before
from homeassistant.const import CONCENTRATION_PARTS_PER_MILLION
native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION
# after
from homeassistant.const import UnitOfRatio
native_unit_of_measurement=UnitOfRatio.PARTS_PER_MILLION
```

In HA Core the old name is now `DeprecatedConstantEnum(UnitOfRatio.PARTS_PER_MILLION, "2027.8")` — both resolve to `"ppm"`, so entity units, state and history are unchanged.

## Note on the minimum Home Assistant version

`UnitOfRatio` was **added in HA Core 2026.7.0** — it is not present in the 2026.4, 2026.5 or 2026.6 tags. This PR therefore also adds `"homeassistant": "2026.7.0"` to `hacs.json`, otherwise HACS would offer the integration to installations where the import fails.

That is a maintainer decision, so please treat it as a proposal: if you would rather keep older Home Assistant versions supported, the alternative is the plain `"ppm"` string, which needs no version floor at all. Happy to change it either way.

This is the only deprecated `homeassistant.const` constant used by the integration.

## Verification

- `python -m compileall custom_components/tuya_ble` passes.
- No occurrence of `CONCENTRATION_PARTS_PER_MILLION` left in the integration.

Reported against `2026.05.14` on Home Assistant Core 2026.8 (HAOS, Python 3.14).

https://claude.ai/code/session_01BA8D88w54PfoqN6p5RRXGj
