### PR TITLE
Return an empty mapping for devices without lights

### DIFF
--- a/custom_components/tuya_ble/light.py
+++ b/custom_components/tuya_ble/light.py
@@ -496,15 +496,17 @@ def update_mapping(category_description: tuple[TuyaLightEntityDescription], mapp
 
     return m
 
-def get_mapping_by_device(device: TuyaBLEDevice) -> tuple[TuyaLightEntityDescription]:
+def get_mapping_by_device(device: TuyaBLEDevice) -> tuple[TuyaLightEntityDescription, ...]:
     category_mapping = LIGHTS.get(device.category)
+    if category_mapping is None:
+        return ()
 
     category = ProductsMapping.get(device.category)
     if category is not None:
         product_mapping_overrides = category.get(device.product_id)
         if product_mapping_overrides is not None:
-             return update_mapping(category_mapping, product_mapping_overrides)
-             
+            return update_mapping(category_mapping, product_mapping_overrides)
+
     return category_mapping
 
 


### PR DESCRIPTION
Fixes #16

## Problem

`get_mapping_by_device()` in `light.py` returns `LIGHTS.get(device.category)` directly, so a device whose category has no light mapping yields `None`. `async_setup_entry()` iterates that result unconditionally:

```
2026-08-10 10:08:53 ERROR (homeassistant.components.light) [helpers/entity_platform.py:499]
Error while setting up tuya_ble platform for light: 'NoneType' object is not iterable
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 499, in _async_setup_platform
    await asyncio.shield(awaitable)
  File "/config/custom_components/tuya_ble/light.py", line 885, in async_setup_entry
    for desc in descs:
                ^^^^^
TypeError: 'NoneType' object is not iterable
```

The failure is not device-specific: one unmapped device takes down the whole `light` platform for every Tuya BLE device on the system. On the system this was reproduced on there is no Tuya BLE light at all — only a lock (category `ms`), which has no `LIGHTS` entry.

Issue #16 reports the same traceback on `2026.3.0` / HA 2026.3.1. It is still present on `2026.05.14` / HA Core 2026.8 — same file, same line, two Home Assistant majors later.

## Fix

Return early with an empty tuple when the category has no light mapping. This makes the function match the contract every other platform already follows — `sensor.py`, `switch.py`, `select.py`, `number.py`, `text.py`, `button.py`, `binary_sensor.py` and `climate.py` all return an empty collection for an unknown device; `light.py` was the only one returning `None`.

The early return is deliberately placed before the `ProductsMapping` branch rather than as a default on `LIGHTS.get()`. A default would only cover the final `return`; `update_mapping()` would still be called with an empty first argument, and it does `list(category_description)` followed by `pop(0)` per override — so `None` raises `TypeError` and `()` raises `IndexError`. Note that this second path is **not reachable today**, since the only `ProductsMapping` category (`"dd"`) is also present in `LIGHTS`; the guard just keeps the contract intact when the tables are extended.

The return annotation is corrected to `tuple[TuyaLightEntityDescription, ...]`, matching how `LIGHTS` itself is annotated.

## Verification

- `python -m compileall custom_components/tuya_ble` passes.
- Mapping contract checked for the four relevant shapes: unmapped category (`ms`) → `()`, mapped category with product override (`dd`/`nvfrtxlq`) → merged description, mapped category without override (`dd`/unknown) → category description, unknown category → `()`. Only the first one changes behaviour, from a raised `TypeError` to an empty result.

https://claude.ai/code/session_01BA8D88w54PfoqN6p5RRXGj
