### PR TITLE
Report transitional lock state until the device confirms

### DIFF
--- a/custom_components/tuya_ble/lock.py
+++ b/custom_components/tuya_ble/lock.py
@@ -2,17 +2,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable
-import asyncio
 
 from homeassistant.components.lock import (
     LockEntity,
     LockEntityDescription,
-    LockEntityFeature,
-    LockState,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -29,7 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 @dataclass
 class TuyaBLELockMapping:
     """Mapping for Tuya BLE Lock."""
-    
+
     lock_dp_id: int  # DP for controlling lock (automatic_lock)
     state_dp_id: int  # DP for reading lock state (lock_motor_state)
     reverse: bool
@@ -39,7 +34,7 @@ class TuyaBLELockMapping:
 @dataclass
 class TuyaBLECategoryLockMapping:
     """Mapping for Tuya BLE Lock by category."""
-    
+
     products: dict[str, list[TuyaBLELockMapping]] | None = None
 
 
@@ -69,18 +64,18 @@ def get_mapping_by_device(
     category = device.category
     product_id = device.product_id
     mappings: list[TuyaBLELockMapping] = []
-    
+
     if category in category_mapping:
         category_map = category_mapping[category]
         if category_map.products and product_id in category_map.products:
             mappings.extend(category_map.products[product_id])
-    
+
     return mappings
 
 
 class TuyaBLELock(TuyaBLEEntity, LockEntity):
     """Representation of a Tuya BLE Lock."""
-    
+
     def __init__(
         self,
         hass: HomeAssistant,
@@ -96,69 +91,85 @@ class TuyaBLELock(TuyaBLEEntity, LockEntity):
         )
         super().__init__(hass, coordinator, device, product, description)
         self._mapping = mapping
-        self._target_state: bool | None = None
-        self._current_state: bool | None = None
-    
+        # Locked state requested by the user, cleared once the device confirms it.
+        self._requested_locked: bool | None = None
+
+    def _logical_value(self, dp_id: int) -> bool | None:
+        """Return a datapoint as a locked state, None if never reported."""
+        datapoint = self._device.datapoints[dp_id]
+        if datapoint is None:
+            return None
+        return self._mapping.reverse ^ bool(datapoint.value)
+
+    @property
+    def _reported_locked(self) -> bool | None:
+        """Return the locked state as last reported by the device."""
+        if self._mapping.state_dp_id > 0:
+            return self._logical_value(self._mapping.state_dp_id)
+        # Without a state datapoint the control datapoint is all there is, and
+        # it already holds the requested value, so a mapping configured this way
+        # reports the new state immediately instead of a transitional one.
+        return self._logical_value(self._mapping.lock_dp_id)
+
     @property
     def is_locked(self) -> bool | None:
-        """Return true if the lock is locked."""
-        return self._target_state is True and self._current_state is not False 
-    
+        """Return true if the lock is locked, None while it is unknown."""
+        return self._reported_locked
+
     @property
     def is_locking(self) -> bool:
         """Return true if the lock is locking."""
-        return self._target_state is True and self._current_state is False
-    
+        return self._requested_locked is True and self._reported_locked is not True
+
     @property
     def is_unlocking(self) -> bool:
         """Return true if the lock is unlocking."""
-        return self._target_state is False and self._current_state is True
-    
+        return self._requested_locked is False and self._reported_locked is not False
 
     async def async_lock(self, **kwargs) -> None:
         """Lock the lock."""
-
-        self._target_state = not self._mapping.reverse
-        self.async_write_ha_state()
-
-        datapoint = self._device.datapoints.get_or_create(
-            self._mapping.lock_dp_id,
-            TuyaBLEDataPointType.DT_BOOL,
-            not self._mapping.reverse,
-        )
-        
-        if datapoint:
-            self._hass.create_task(datapoint.set_value(not self._mapping.reverse))
-
+        await self._async_request_locked(True)
 
     async def async_unlock(self, **kwargs) -> None:
         """Unlock the lock."""
-        
-        self._target_state = self._mapping.reverse
+        await self._async_request_locked(False)
+
+    async def _async_request_locked(self, locked: bool) -> None:
+        """Ask the device to lock or unlock and wait for it to confirm."""
+        _LOGGER.debug(
+            "%s: Requesting lock state %s",
+            self._device.address,
+            "locked" if locked else "unlocked",
+        )
+
+        # Reported immediately as is_locking/is_unlocking, until the device
+        # reports the new state through its own datapoint.
+        self._requested_locked = locked
         self.async_write_ha_state()
 
+        value = self._mapping.reverse ^ locked
         datapoint = self._device.datapoints.get_or_create(
             self._mapping.lock_dp_id,
             TuyaBLEDataPointType.DT_BOOL,
-            self._mapping.reverse,
+            value,
         )
+        try:
+            await datapoint.set_value(value)
+        except Exception:
+            self._requested_locked = None
+            self.async_write_ha_state()
+            raise
 
-        if datapoint:
-            self._hass.create_task(datapoint.set_value(self._mapping.reverse))
-        
-    
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        # Check both lock_motor_state and automatic_lock datapoints for changes
-        lock_datapoint = self._device.datapoints[self._mapping.lock_dp_id]
-        if lock_datapoint:
-            self._target_state = self._mapping.reverse ^ bool(lock_datapoint.value)
-
-        if self._mapping.state_dp_id > 0:
-            state_datapoint = self._device.datapoints[self._mapping.state_dp_id]
-            if state_datapoint:
-                self._current_state = self._mapping.reverse ^ bool(state_datapoint.value)
+        # The transition ends only once the device reports the requested state;
+        # any other report means the motor has not finished moving yet.
+        if (
+            self._requested_locked is not None
+            and self._reported_locked == self._requested_locked
+        ):
+            self._requested_locked = None
 
         self.async_write_ha_state()
 
@@ -171,7 +182,7 @@ async def async_setup_entry(
     """Set up Tuya BLE lock platform."""
     data: TuyaBLEData = hass.data[DOMAIN][entry.entry_id]
     mappings = get_mapping_by_device(data.device)
-    
+
     entities: list[TuyaBLELock] = []
     for mapping in mappings:
         entities.append(
@@ -183,5 +194,5 @@ async def async_setup_entry(
                 mapping,
             )
         )
-    
+
     async_add_entities(entities)


### PR DESCRIPTION
Follow-up to #13, which added the lock platform. Its description promised transitional states, but the implementation did not deliver them, and two further problems turned up alongside. All three are fixed here and verified on the hardware #13 was written for.

## The transitional state never appeared

`TuyaBLELock` kept two contradictory conventions in the same field:

```python
# async_lock / async_unlock  -- raw datapoint value
self._target_state = not self._mapping.reverse

# _handle_coordinator_update -- logical value
self._target_state = self._mapping.reverse ^ bool(lock_datapoint.value)
```

The two agree when `reverse` is `False` and are exact opposites when it is `True`. The only mapped product, the `0qxp5u7s` Smart Lock, uses `reverse=True`, so pressing Lock briefly published *unlocked*, and the transitional state only appeared once the device echoed DP 33 back. Hardware without `reverse` does not show the problem.

## Locking the device by hand never reached Home Assistant

`is_locked` was `_target_state is True and _current_state is not False`, and `_target_state` came only from DP 33 (`automatic_lock`). Turning the key, entering a code or using a fingerprint does not send DP 33, so the entity could not report `locked` at all - an affected lock stays on `unlocked` indefinitely.

## The write was fire-and-forget

`self._hass.create_task(datapoint.set_value(...))` dropped BLE write failures on the floor, and any datapoint report arriving before the write finished recomputed the target from the pre-write value of DP 33, which put the entity back into a transitional state after the operation had already completed.

## What this changes

State is derived from the datapoints inside the properties, the way the other platforms in this integration already do it (`sensor.py`, `switch.py::is_on`), instead of being cached in entity fields. The only state the entity keeps is the requested value:

- `is_locked` reports `lock_motor_state`, so external changes are reflected.
- `is_locking` / `is_unlocking` are driven by an explicit pending flag, cleared only once the device reports the requested state, so the final state is never published before the motor has finished.
- `async_lock` / `async_unlock` await the write and clear the pending flag if it raises.

**One user-visible change beyond the fix:** `is_locked` can now return `None`, so a lock reports `unknown` until the device has sent its state instead of claiming to be unlocked. That is what the HA lock entity documentation prescribes, but it is a state existing installations have not seen before.

Mappings with `state_dp_id=0` keep publishing the requested value immediately. They have nothing to wait for: `set_value` updates the cached datapoint before sending, so a datapoint the command path writes can never serve as confirmation. A comment in `_reported_locked` records this.

Unused imports left over from #13 (`Callable`, `asyncio`, `LockEntityFeature`, `LockState`, `EntityCategory`) are dropped in the same commit.

## Verification

Hardware: Smart Lock `0qxp5u7s`, category `ms`, `reverse=True`, Home Assistant 2026.8.1.

Logbook for one manual cycle followed by one cycle driven from Home Assistant:

```
22:46:53  unknown      restart, DP 47 not reported yet
22:49:52  locked       locked by hand   <- previously impossible
22:49:55  unlocked     unlocked by hand
22:51:15  locking      lock.lock
22:51:16  locked       DP 47 confirmed, +1.66 s
22:52:19  unlocking    lock.unlock
22:52:21  unlocked     DP 47 confirmed, +2.51 s
```

### On the `unknown` state

`async_setup_entry` already asks the device for its status through `hass.add_job(device.update())`, but that does not guarantee `lock_motor_state` comes back. Observed both ways on the same lock across two restarts: once the datapoint arrived within seconds and the entity came up as `unlocked`, once it did not arrive until the lock was next operated and the entity stayed `unknown` for minutes.

So `unknown` after a restart is a real state for this platform rather than a transient one. It is still better than reporting `unlocked` without knowing anything. `RestoreEntity` is the mechanism if that turns out to bother users; asking the device again is not, since the integration already does.
