### PR TITLE
Report who opened the lock, from datapoints read off the device

### DIFF
--- a/custom_components/tuya_ble/__init__.py
+++ b/custom_components/tuya_ble/__init__.py
@@ -15,12 +15,14 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from .tuya_ble import TuyaBLEDevice
 
 from .cloud import HASSTuyaBLEDeviceManager
+from . import lock_capabilities
 from .const import DOMAIN
 from .devices import TuyaBLECoordinator, TuyaBLEData, get_device_product_info
 
 PLATFORMS: list[Platform] = [
     Platform.BUTTON,
     Platform.CLIMATE,
+    Platform.EVENT,
     Platform.LOCK,
     Platform.NUMBER,
     Platform.SENSOR,
@@ -47,6 +49,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
     device = TuyaBLEDevice(manager, ble_device)
     await device.initialize()
+
+    # Code, id and type only: the credentials object carries the local key.
+    _LOGGER.debug(
+        "%s: category=%s product=%s functions=%s status=%s",
+        address,
+        device.category,
+        device.product_id,
+        sorted((f.dp_id, code, str(f.type)) for code, f in device.function.items()),
+        sorted(
+            (f.dp_id, code, str(f.type)) for code, f in device.status_range.items()
+        ),
+    )
+
     product_info = get_device_product_info(device)
 
     coordinator = TuyaBLECoordinator(hass, device)
@@ -80,13 +95,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
     )
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = TuyaBLEData(
+    data = TuyaBLEData(
         entry.title,
         device,
         product_info,
         manager,
         coordinator,
     )
+    # Not in the lock platform: some products in this schema report unlocks
+    # without exposing anything to control, so they get no lock entity, and the
+    # event platform still needs the answer.
+    data.lock_capabilities = lock_capabilities.discover(device)
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = data
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -1,7 +1,7 @@
 """The Tuya BLE integration."""
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import logging
 from homeassistant.const import CONF_ADDRESS, CONF_DEVICE_ID
@@ -38,6 +38,11 @@ from .const import (
 
 from .base import IntegerTypeData, EnumTypeData
 from .tuya_ble import TuyaBLEDataPointType, TuyaBLEDevice
+
+if TYPE_CHECKING:
+    # Only for the annotations on TuyaBLEData: importing these for real would
+    # have this module depend on the lock support it merely carries.
+    from .lock_capabilities import TuyaBLELockCapabilities
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -306,6 +311,9 @@ class TuyaBLEData:
     product: TuyaBLEProductInfo
     manager: HASSTuyaBLEDeviceManager
     coordinator: TuyaBLECoordinator
+    # Access control datapoints this device turned out to have. Discovered
+    # before the platforms are set up, because more than one of them needs it.
+    lock_capabilities: TuyaBLELockCapabilities | None = None
 
 
 @dataclass

--- a/custom_components/tuya_ble/event.py
+++ b/custom_components/tuya_ble/event.py
@@ -1,0 +1,129 @@
+"""Unlock events for Tuya BLE locks.
+
+The `unlock_*` sensors carry the same datapoints, but a sensor only notifies on
+a change, so repeated unlocks with the same credential are indistinguishable
+from no unlock at all. An event entity carries a timestamp per trigger, so
+opening the door twice with the same finger is two events.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.event import EventEntity, EventEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .tuya_ble import TuyaBLEDataPoint, TuyaBLEDevice
+
+from .const import DOMAIN
+from .devices import TuyaBLECoordinator, TuyaBLEData, TuyaBLEEntity, TuyaBLEProductInfo
+from .lock_capabilities import TuyaBLELockCapabilities
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_CREDENTIAL_ID = "credential_id"
+
+
+class TuyaBLELockUnlockEvent(TuyaBLEEntity, EventEntity):
+    """Fires whenever the lock reports how it was opened."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        coordinator: TuyaBLECoordinator,
+        device: TuyaBLEDevice,
+        product: TuyaBLEProductInfo,
+        entry: ConfigEntry,
+        capabilities: TuyaBLELockCapabilities,
+    ) -> None:
+        """Initialize the event entity."""
+        self._entry = entry
+        self._dp_events = dict(capabilities.unlock_records)
+        super().__init__(
+            hass,
+            coordinator,
+            device,
+            product,
+            EventEntityDescription(key="unlocked"),
+        )
+        self._attr_event_types = sorted(set(self._dp_events.values()))
+        # Datapoints whose first report on the current connection has already
+        # been seen and discarded.
+        self._seen: set[int] = set()
+
+    async def async_added_to_hass(self) -> None:
+        """Start listening for unlock reports."""
+        await super().async_added_to_hass()
+        self.async_on_remove(self._device.register_callback(self._handle_report))
+        self.async_on_remove(
+            self._device.register_disconnected_callback(self._handle_disconnect)
+        )
+
+    @callback
+    def _handle_disconnect(self) -> None:
+        """Expect a replayed status again once the lock comes back.
+
+        Every connection begins with a status query, so the replay described in
+        _handle_report happens on each reconnection and not only at startup.
+        """
+        self._seen.clear()
+
+    @callback
+    def _handle_report(self, datapoints: list[TuyaBLEDataPoint]) -> None:
+        """Turn an unlock report into an event."""
+        for datapoint in datapoints:
+            event_type = self._dp_events.get(datapoint.id)
+            if event_type is None:
+                continue
+
+            # Connecting asks the lock for its whole status, and the lock
+            # answers with the last value of every datapoint, including the
+            # credential that opened the door last - possibly days ago. That is
+            # history, not an event, and the receive timestamp cannot tell the
+            # two apart, because datapoints are stamped when they arrive rather
+            # than when the lock recorded them. So the first report of each
+            # datapoint on a connection is dropped, at the cost of missing an
+            # unlock in the first seconds of a connection.
+            if datapoint.id not in self._seen:
+                self._seen.add(datapoint.id)
+                continue
+
+            # Fired on every report, not only when the value changes: the same
+            # finger opening the door twice has to be two events.
+            self._trigger_event(event_type, self._describe(datapoint.value))
+            self.async_write_ha_state()
+
+    def _describe(self, credential_id: int) -> dict[str, Any]:
+        """Describe the credential the lock named, which is only a number."""
+        return {ATTR_CREDENTIAL_ID: credential_id}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Tuya BLE lock events."""
+    data: TuyaBLEData = hass.data[DOMAIN][entry.entry_id]
+    capabilities = data.lock_capabilities
+
+    # Deliberately not tied to the lock platform's mapping. A lock that reports
+    # how it was opened but cannot be operated from Home Assistant - several of
+    # them have no controllable datapoint at all - still deserves this entity.
+    if capabilities is None or not capabilities.reports_unlocks:
+        return
+
+    async_add_entities(
+        [
+            TuyaBLELockUnlockEvent(
+                hass,
+                data.coordinator,
+                data.device,
+                data.product,
+                entry,
+                capabilities,
+            )
+        ]
+    )

--- a/custom_components/tuya_ble/lock.py
+++ b/custom_components/tuya_ble/lock.py
@@ -11,10 +11,11 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .tuya_ble import TuyaBLEDataPointType, TuyaBLEDevice
+from .tuya_ble import TuyaBLEDataPoint, TuyaBLEDataPointType, TuyaBLEDevice
 
 from .const import DOMAIN
 from .devices import TuyaBLECoordinator, TuyaBLEData, TuyaBLEEntity, TuyaBLEProductInfo
+from .lock_capabilities import TuyaBLELockCapabilities
 
 import logging
 
@@ -83,6 +84,7 @@ class TuyaBLELock(TuyaBLEEntity, LockEntity):
         device: TuyaBLEDevice,
         product: TuyaBLEProductInfo,
         mapping: TuyaBLELockMapping,
+        capabilities: TuyaBLELockCapabilities | None = None,
     ) -> None:
         """Initialize the lock."""
         description = mapping.description or LockEntityDescription(
@@ -93,6 +95,9 @@ class TuyaBLELock(TuyaBLEEntity, LockEntity):
         self._mapping = mapping
         # Locked state requested by the user, cleared once the device confirms it.
         self._requested_locked: bool | None = None
+        self._unlock_dps = dict(capabilities.unlock_records) if capabilities else {}
+        # Datapoints whose replayed value has been discarded on this connection.
+        self._seen_unlock_dps: set[int] = set()
 
     def _logical_value(self, dp_id: int) -> bool | None:
         """Return a datapoint as a locked state, None if never reported."""
@@ -110,6 +115,42 @@ class TuyaBLELock(TuyaBLEEntity, LockEntity):
         # it already holds the requested value, so a mapping configured this way
         # reports the new state immediately instead of a transitional one.
         return self._logical_value(self._mapping.lock_dp_id)
+
+    async def async_added_to_hass(self) -> None:
+        """Start tracking who last operated the lock."""
+        await super().async_added_to_hass()
+        if self._unlock_dps:
+            self.async_on_remove(
+                self._device.register_callback(self._handle_unlock_record)
+            )
+            self.async_on_remove(
+                self._device.register_disconnected_callback(self._handle_disconnect)
+            )
+
+    @callback
+    def _handle_disconnect(self) -> None:
+        """Expect the replayed status again once the lock comes back."""
+        self._seen_unlock_dps.clear()
+
+    @callback
+    def _handle_unlock_record(self, datapoints: list[TuyaBLEDataPoint]) -> None:
+        """Record who opened the lock, for LockEntity.changed_by.
+
+        The first report of each datapoint on a connection is dropped, exactly
+        as the event entity drops it: the lock answers a status query with the
+        last value of every datapoint, and that value is not merely stale. It
+        can name a credential that no longer exists on the lock, which is worse
+        than reporting nothing until someone actually opens the door.
+        """
+        for datapoint in datapoints:
+            method = self._unlock_dps.get(datapoint.id)
+            if method is None:
+                continue
+            if datapoint.id not in self._seen_unlock_dps:
+                self._seen_unlock_dps.add(datapoint.id)
+                continue
+            self._attr_changed_by = f"{method} #{datapoint.value}"
+            self.async_write_ha_state()
 
     @property
     def is_locked(self) -> bool | None:
@@ -192,6 +233,7 @@ async def async_setup_entry(
                 data.device,
                 data.product,
                 mapping,
+                data.lock_capabilities,
             )
         )
 

--- a/custom_components/tuya_ble/lock_capabilities.py
+++ b/custom_components/tuya_ble/lock_capabilities.py
@@ -1,0 +1,118 @@
+"""Which access control datapoints a Tuya lock exposes.
+
+Tuya locks share a platform-wide datapoint schema: 0qxp5u7s, isk2p555 and
+ludzroix carry the same codes on the same datapoint ids. The integration
+already downloads the product specification and keeps it in `device.function`
+and `device.status_range`, keyed by code and carrying the datapoint id, so the
+ids are looked up there rather than tabulated per product - which also covers
+locks nobody here can test.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import logging
+
+from .tuya_ble import TuyaBLEDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+CODE_CREDENTIAL_ADD = "unlock_method_create"
+CODE_CREDENTIAL_DELETE = "unlock_method_delete"
+CODE_CREDENTIAL_SYNC = "synch_method"
+
+# Every way a Tuya lock reports that it was opened, mapped to the name the
+# event entity exposes. The lock only has the ones its hardware supports.
+UNLOCK_RECORD_CODES: dict[str, str] = {
+    "unlock_fingerprint": "fingerprint",
+    "unlock_password": "password",
+    "unlock_dynamic": "dynamic_password",
+    "unlock_temporary": "temporary_password",
+    "unlock_card": "card",
+    "unlock_face": "face",
+    "unlock_key": "key",
+    "unlock_ble": "bluetooth",
+    "unlock_phone_remote": "remote",
+    "unlock_voice_remote": "voice",
+    "unlock_offline_pd": "offline_password",
+}
+
+
+@dataclass
+class TuyaBLELockCapabilities:
+    """Datapoint ids this particular lock exposes, zero when it does not."""
+
+    credential_add_dp_id: int = 0
+    credential_delete_dp_id: int = 0
+    credential_sync_dp_id: int = 0
+    # Datapoint id -> unlock method name.
+    unlock_records: dict[int, str] = field(default_factory=dict)
+
+    @property
+    def manages_credentials(self) -> bool:
+        """Return true if credentials can be listed, which is the entry point."""
+        return self.credential_sync_dp_id > 0
+
+    @property
+    def reports_unlocks(self) -> bool:
+        """Return true if the lock says how it was opened."""
+        return bool(self.unlock_records)
+
+
+# Fallback for config entries whose cached specification predates the version
+# that started storing it. A product that is listed neither here nor in a
+# specification gets nothing.
+FALLBACK_CAPABILITIES: dict[str, TuyaBLELockCapabilities] = {
+    "0qxp5u7s": TuyaBLELockCapabilities(
+        credential_add_dp_id=1,
+        credential_delete_dp_id=2,
+        credential_sync_dp_id=54,
+        unlock_records={12: "fingerprint", 19: "bluetooth", 62: "remote", 63: "voice"},
+    ),
+}
+
+
+def _find_dp_id(device: TuyaBLEDevice, code: str) -> int:
+    """Return the datapoint id the device gives a code, or zero."""
+    for source in (device.function, device.status_range):
+        entry = source.get(code)
+        if entry is not None and entry.dp_id:
+            return int(entry.dp_id)
+    return 0
+
+
+def discover(device: TuyaBLEDevice) -> TuyaBLELockCapabilities:
+    """Read a lock's access control datapoints off its own specification."""
+    fallback = FALLBACK_CAPABILITIES.get(
+        device.product_id, TuyaBLELockCapabilities()
+    )
+    capabilities = TuyaBLELockCapabilities(
+        credential_add_dp_id=(
+            _find_dp_id(device, CODE_CREDENTIAL_ADD) or fallback.credential_add_dp_id
+        ),
+        credential_delete_dp_id=(
+            _find_dp_id(device, CODE_CREDENTIAL_DELETE)
+            or fallback.credential_delete_dp_id
+        ),
+        credential_sync_dp_id=(
+            _find_dp_id(device, CODE_CREDENTIAL_SYNC) or fallback.credential_sync_dp_id
+        ),
+        # All or nothing rather than per datapoint: a specification that names
+        # any unlock record describes the whole lock, so mixing the two sources
+        # could only add records the lock does not have.
+        unlock_records={
+            dp_id: method
+            for code, method in UNLOCK_RECORD_CODES.items()
+            if (dp_id := _find_dp_id(device, code))
+        }
+        or dict(fallback.unlock_records),
+    )
+
+    _LOGGER.debug(
+        "%s: lock capabilities add=%s delete=%s sync=%s unlock records=%s",
+        device.address,
+        capabilities.credential_add_dp_id,
+        capabilities.credential_delete_dp_id,
+        capabilities.credential_sync_dp_id,
+        capabilities.unlock_records,
+    )
+    return capabilities

--- a/custom_components/tuya_ble/strings.json
+++ b/custom_components/tuya_ble/strings.json
@@ -230,6 +230,28 @@
       "program": {
         "name": "Program: position[/time];..."
       }
+    },
+    "event": {
+      "unlocked": {
+        "name": "Unlocked by",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "fingerprint": "Fingerprint",
+              "password": "Password",
+              "dynamic_password": "Dynamic password",
+              "temporary_password": "Temporary password",
+              "card": "Card",
+              "face": "Face",
+              "key": "Key",
+              "bluetooth": "Bluetooth",
+              "remote": "Remote",
+              "voice": "Voice",
+              "offline_password": "Offline password"
+            }
+          }
+        }
+      }
     }
   },
   "options": {

--- a/custom_components/tuya_ble/translations/en.json
+++ b/custom_components/tuya_ble/translations/en.json
@@ -230,6 +230,28 @@
             "program": {
                 "name": "Program: position[/time];..."
             }
+        },
+        "event": {
+            "unlocked": {
+                "name": "Unlocked by",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "fingerprint": "Fingerprint",
+                            "password": "Password",
+                            "dynamic_password": "Dynamic password",
+                            "temporary_password": "Temporary password",
+                            "card": "Card",
+                            "face": "Face",
+                            "key": "Key",
+                            "bluetooth": "Bluetooth",
+                            "remote": "Remote",
+                            "voice": "Voice",
+                            "offline_password": "Offline password"
+                        }
+                    }
+                }
+            }
         }
     },
     "options": {

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,18 @@
+# Off-hardware checks for the lock support
+
+Plain scripts, no framework, no dependencies beyond the standard library - the
+module they cover imports neither Home Assistant nor bleak, which is a property
+worth keeping.
+
+```
+python3 tests/test_lock_capabilities.py   # which datapoints a given lock has
+```
+
+Exits non-zero on the first failure.
+
+The product specifications it asserts against were captured from real devices
+rather than copied out of the Tuya reference; where the two disagree, the
+comments say so and the capture wins.
+
+`TUYA_BLE_COMPONENT` points the harness at another copy of the component, which
+is how a change can be checked against the behaviour before it.

--- a/tests/test_lock_capabilities.py
+++ b/tests/test_lock_capabilities.py
@@ -1,0 +1,182 @@
+"""Checks for lock_capabilities.discover.
+
+Pins three product specifications captured from real devices, plus the two ways
+a lock can end up with no specification at all.
+
+    python3 tests/test_lock_capabilities.py
+
+Set TUYA_BLE_COMPONENT to point it at another copy of the component.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+
+COMPONENT = Path(
+    os.environ.get(
+        "TUYA_BLE_COMPONENT",
+        Path(__file__).resolve().parents[1] / "custom_components" / "tuya_ble",
+    )
+)
+
+
+def _load(name: str, path: Path):
+    """Import a module by path, with a stub package so relative imports work."""
+    package = "tuya_ble_stub"
+    if package not in sys.modules:
+        stub = types.ModuleType(package)
+        stub.__path__ = [str(COMPONENT)]
+        sys.modules[package] = stub
+        # lock_capabilities only needs the TuyaBLEDevice name for annotations.
+        ble = types.ModuleType(f"{package}.tuya_ble")
+        ble.TuyaBLEDevice = object
+        sys.modules[f"{package}.tuya_ble"] = ble
+    spec = importlib.util.spec_from_file_location(f"{package}.{name}", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[f"{package}.{name}"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+capabilities = _load("lock_capabilities", COMPONENT / "lock_capabilities.py")
+
+
+@dataclass
+class FakeSpec:
+    """Stands in for the cloud specification entry of one datapoint."""
+
+    dp_id: int
+
+
+class FakeDevice:
+    """Only the three attributes discovery reads."""
+
+    def __init__(self, product_id: str, function: dict, status_range: dict) -> None:
+        self.address = "AA:BB:CC:DD:EE:FF"
+        self.product_id = product_id
+        self.function = {code: FakeSpec(dp) for code, dp in function.items()}
+        self.status_range = {code: FakeSpec(dp) for code, dp in status_range.items()}
+
+
+FAILURES = 0
+
+
+def check(label: str, actual, expected) -> None:
+    global FAILURES
+    if actual == expected:
+        print(f"  ok  {label}")
+        return
+    FAILURES += 1
+    print(f"  FAIL {label}\n       expected {expected!r}\n       got      {actual!r}")
+
+
+# The write side lives in function and the reporting side in status_range,
+# exactly as the cloud returns it.
+SPEC_0QXP5U7S_FUNCTION = {
+    "unlock_method_create": 1,
+    "unlock_method_delete": 2,
+    "synch_method": 54,
+    "automatic_lock": 33,
+}
+SPEC_0QXP5U7S_STATUS = {
+    "unlock_fingerprint": 12,
+    "unlock_ble": 19,
+    "unlock_phone_remote": 62,
+    "unlock_voice_remote": 63,
+    "lock_motor_state": 47,
+    "synch_method": 54,
+}
+
+# From the specification quoted in issue #1713, for a lock with no entry in
+# FALLBACK_CAPABILITIES.
+SPEC_ISK2P555_FUNCTION = {
+    "unlock_method_create": 1,
+    "unlock_method_delete": 2,
+    "synch_method": 54,
+}
+SPEC_ISK2P555_STATUS = {
+    "unlock_fingerprint": 12,
+    "unlock_password": 13,
+    "unlock_dynamic": 14,
+    "unlock_temporary": 55,
+    "unlock_ble": 19,
+    "unlock_phone_remote": 62,
+    "unlock_voice_remote": 63,
+    "unlock_offline_pd": 67,
+}
+
+print("a lock with a hand-written fallback")
+found = capabilities.discover(
+    FakeDevice("0qxp5u7s", SPEC_0QXP5U7S_FUNCTION, SPEC_0QXP5U7S_STATUS)
+)
+check("add datapoint", found.credential_add_dp_id, 1)
+check("delete datapoint", found.credential_delete_dp_id, 2)
+check("sync datapoint", found.credential_sync_dp_id, 54)
+check(
+    "unlock records",
+    found.unlock_records,
+    {12: "fingerprint", 19: "bluetooth", 62: "remote", 63: "voice"},
+)
+check("manages credentials", found.manages_credentials, True)
+check("reports unlocks", found.reports_unlocks, True)
+check(
+    "matches the hand-written fallback exactly",
+    found,
+    capabilities.FALLBACK_CAPABILITIES["0qxp5u7s"],
+)
+
+print("a lock discovered from its specification alone")
+found = capabilities.discover(
+    FakeDevice("isk2p555", SPEC_ISK2P555_FUNCTION, SPEC_ISK2P555_STATUS)
+)
+check("add datapoint", found.credential_add_dp_id, 1)
+check("delete datapoint", found.credential_delete_dp_id, 2)
+check("sync datapoint", found.credential_sync_dp_id, 54)
+check(
+    "eight unlock methods",
+    found.unlock_records,
+    {
+        12: "fingerprint",
+        13: "password",
+        14: "dynamic_password",
+        55: "temporary_password",
+        19: "bluetooth",
+        62: "remote",
+        63: "voice",
+        67: "offline_password",
+    },
+)
+
+print("no specification at all")
+check(
+    "a known product still falls back to the measured datapoints",
+    capabilities.discover(FakeDevice("0qxp5u7s", {}, {})),
+    capabilities.FALLBACK_CAPABILITIES["0qxp5u7s"],
+)
+bare = capabilities.discover(FakeDevice("unknown_lock", {}, {}))
+check("an unknown product gets nothing", bare, capabilities.TuyaBLELockCapabilities())
+check("and does not claim to manage credentials", bare.manages_credentials, False)
+
+print("a device that is not a lock")
+fingerbot = capabilities.discover(
+    FakeDevice("blliqpsj", {"mode": 8, "click_sustain_time": 10}, {"battery_percentage": 12})
+)
+check("no credential datapoints", fingerbot.manages_credentials, False)
+check("no unlock records", fingerbot.unlock_records, {})
+
+print("the fallback table is not handed out to be mutated")
+first = capabilities.discover(FakeDevice("0qxp5u7s", {}, {}))
+first.unlock_records[99] = "nonsense"
+check(
+    "a second lookup is unaffected",
+    capabilities.discover(FakeDevice("0qxp5u7s", {}, {})).unlock_records,
+    {12: "fingerprint", 19: "bluetooth", 62: "remote", 63: "voice"},
+)
+
+print()
+print("all green" if FAILURES == 0 else f"{FAILURES} FAILED")
+sys.exit(1 if FAILURES else 0)


### PR DESCRIPTION
# Report who opened the lock, and read the access control datapoints off the device

Adds attribution for lock unlocks: an `event` entity that fires on every unlock the
lock reports, and `LockEntity.changed_by`. The datapoint ids behind it are read from
the product specification the integration already downloads, rather than hardcoded
per product, so locks nobody here owns get the same handling.

Nothing is removed or changed for existing users. The `unlock_*` sensors stay exactly
as they are.

## Why the existing sensor is not enough

`sensor.*_unlock_fingerprint` reports the hardware id of the credential that last
opened the door. A sensor only notifies on a **change**, so someone who always uses
the same finger changes nothing and every automation stays asleep. On the lock this
was written against, that sensor had been reporting the same value for a month for
exactly that reason.

Measured, four unlocks in a row - twice with one finger, then twice with another:

| | triggers |
|---|---|
| `sensor.*_unlock_fingerprint` | **2** |
| `event.*_unlocked_by` | **4** |

An event entity carries a timestamp per trigger, so opening the door twice with the
same finger is two events.

![The event entity, one activity entry per unlock](https://raw.githubusercontent.com/jkolo/ha_tuya_ble/pr-assets/screenshots/05-event-entity.png)

`LockEntity.changed_by` is set from the same reports. Note that Home Assistant does not
render it in the lock's more-info dialog in 2026.8 - checked on a running instance, not
assumed - so its audience is templates and automations, and the event entity is what a
person actually looks at. Measured after a restart followed by one real unlock:

```
lock.front_door                  unlocked
  changed_by                     Lewy Kciuk

event.front_door_unlocked_by     2026-08-13T01:31:02+02:00
  event_type                     fingerprint
  credential_id                  1
```

Before the unlock, `changed_by` is absent rather than reporting the credential the lock
replays - see below.

## The lock lies about its last unlock, and this works around it

Connecting asks the lock for its whole status, and the lock answers with the last
value of every datapoint - including the unlock record. That answer is history, not
an event, and the protocol cannot tell them apart: datapoints are stamped with the
time they arrived, not the time the lock recorded them.

The replayed value is not even stale-but-true. Across three reconnections a `0qxp5u7s`
answered the unlock datapoint with credential `2` every time, while the real last opener
had been `0` and then `1` - and the lock holds only `0` and `1`, which it confirms when
asked to list its credentials. A deleted credential can therefore be named as the last
one through the door.

So the first report of each datapoint **on each connection** is dropped. It has to be
per connection rather than per startup: a battery powered lock reconnects often, and
each reconnection replays the record, which otherwise surfaces as a phantom unlock.

The cost is an unlock in the first seconds of a connection going unreported, which is
the better side to err on.

## Datapoints are discovered, not hardcoded

`device.function` and `device.status_range` already carry the product specification from
the Tuya cloud, keyed by code and carrying the datapoint id. Three independent lock
products from three vendors - `0qxp5u7s`, `isk2p555`, `ludzroix` - use the same codes on
the same ids, so the ids were never a per-product fact worth a table.

Verified against three captured specifications:

```
0qxp5u7s   {12 fingerprint, 19 bluetooth, 62 remote, 63 voice}
           identical to the values that were measured by hand
isk2p555   {12 fingerprint, 13 password, 14 dynamic, 55 temporary,
            19 bluetooth, 62 remote, 63 voice, 67 offline}
fingerbot  nothing, no false positives
```

A hand-written fallback remains for config entries whose cached specification predates
the version that started storing it.

The event entity is deliberately **not** tied to the lock platform's mapping: several
products in this schema report unlocks but expose nothing to control, so they get no
lock entity at all and would otherwise get no attribution either.

## Tests

`tests/`, plain scripts, no dependencies - the modules they cover import neither Home
Assistant nor bleak.

```
python3 tests/test_lock_capabilities.py
```

## What is measured and what is not

- **Measured on hardware** (`0qxp5u7s`): every datapoint id, the replay behaviour, the
  event/sensor trigger counts above, `changed_by` staying empty after a restart.
- **Not measured**: `isk2p555` and `ludzroix` - discovery is verified against their
  published specifications, but nobody here has one of these locks. They previously got
  nothing at all, so the downside is bounded.

## Relationship to #22

Deliberately kept out of this one. #22 rewrites how the lock reports its own state while
the motor is moving; this only adds attribution, and the two touch `lock.py` in different
places. They can be reviewed and merged in either order - whichever is merged second will
want a trivial rebase.
